### PR TITLE
Remove indirect injected dependancy on handlebars in consuming config.js

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -1,12 +1,8 @@
-export function translate(load) {
-  console.log('compiling template:', load.name);
-  load.source = 'module.exports = require(\'handlebars\').compile(\'' + load.source
-  .replace(/'/g, '\\\'')
-  .replace(/[\f]/g, '\\f')
-  .replace(/[\b]/g, '\\b')
-  .replace(/[\n]/g, '\\n')
-  .replace(/[\t]/g, '\\t')
-  .replace(/[\r]/g, '\\r')
-  .replace(/[\u2028]/g, '\\u2028')
-  .replace(/[\u2029]/g, '\\u2029') + '\');';
+import Handlebars from 'handlebars';
+
+function instantiate(load) {
+    console.log('compiling template:', load.name);
+    return Handlebars.compile(load.source);
 }
+
+export { instantiate };


### PR DESCRIPTION
Currently whilst using this plugin in a project your have to add a direct dependency to handlebars as well otherwise systemjs gets upset when expecting `handlebars` to be configured in your systemjs config.js.

``` javascript
System.config({
...
 map: {
    "handlebars": "github:components/handlebars.js@4.0.3",
    "github:davis/plugin-hbs@1.1.0": {
      "handlebars": "github:components/handlebars.js@4.0.3"
    },
...
});

```

with this pull request the consumer only needs to directly depend on your plugin i.e. by running:
`jspm install hbs`.

which then makes their config.js look like:

``` javascript
System.config({
...
 map: {
    "github:davis/plugin-hbs@1.1.0": {
      "handlebars": "github:components/handlebars.js@4.0.3"
    },
...
});

```
