### PR TITLE
Support for ESM format

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -2,9 +2,16 @@
 
 import Handlebars from 'handlebars';
 
-const handlebarsRuntimePath = System.normalizeSync('handlebars/handlebars.runtime', __moduleName);
-
 export function translate(load) {
-  var precompiled = Handlebars.precompile(load.source);
-  load.source = `module.exports = require('${handlebarsRuntimePath}').template(${precompiled});`;
+  let precompiled = Handlebars.precompile(load.source);
+  let output;
+  if (load.metadata.format === 'esm') {
+    output = `import {Handlebars} from 'handlebars/handlebars.runtime.js'; \n export default Handlebars.template(${precompiled});`;
+  } else if (load.metadata.format === 'amd') {
+    output = `define(['handlebars/handlebars.runtime.js'], function(Handlebars) { return Handlebars.template(${precompiled}); });`;
+  } else {
+    output = `var Handlebars=require('handlebars/handlebars.runtime.js'); \n module.exports = Handlebars.template(${precompiled});`;
+  }
+  load.source = output;
+  return output;
 }


### PR DESCRIPTION
With this modification, you can pick the format that suits you better between ESM, AMD and CJS (default) in the config:

``` js
meta: {
    "*.hbs": {
      "defaultExtension": false,
      "format": "esm",
      "loader": "hbs"
    }
}
```

I resorted to this modification because the hardcoded CJS style translation didn't get along well with rollup static optimization when using `jspm build`.
