### PR TITLE
make fixes for bundling

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -4,13 +4,20 @@ import Handlebars from 'handlebars';
 
 export function translate(load) {
   let precompiled = Handlebars.precompile(load.source);
+  let handlebarsRuntimePath = 'handlebars/handlebars.runtime.js';
+
+  // in builds we want to embed the canonical name for the handlebars runtime
+  if (System.getCanonicalName) {
+    handlebarsRuntimePath = System.getCanonicalName(handlebarsRuntimePath);
+  }
+
   let output;
   if (load.metadata.format === 'esm') {
-    output = `import {Handlebars} from 'handlebars/handlebars.runtime.js'; \n export default Handlebars.template(${precompiled});`;
+    output = `import {Handlebars} from '${handlebarsRuntimePath}'; \n export default Handlebars.template(${precompiled});`;
   } else if (load.metadata.format === 'amd') {
-    output = `define(['handlebars/handlebars.runtime.js'], function(Handlebars) { return Handlebars.template(${precompiled}); });`;
+    output = `define(['${handlebarsRuntimePath}'], function(Handlebars) { return Handlebars.template(${precompiled}); });`;
   } else {
-    output = `var Handlebars=require('handlebars/handlebars.runtime.js'); \n module.exports = Handlebars.template(${precompiled});`;
+    output = `var Handlebars=require('${handlebarsRuntimePath}'); \n module.exports = Handlebars.template(${precompiled});`;
   }
   load.source = output;
   return output;

--- a/hbs.js
+++ b/hbs.js
@@ -4,7 +4,7 @@ import Handlebars from 'handlebars';
 
 export function translate(load) {
   let precompiled = Handlebars.precompile(load.source);
-  let handlebarsRuntimePath = 'handlebars/handlebars.runtime.js';
+  let handlebarsRuntimePath = System.normalizeSync('handlebars/handlebars.runtime.js', __moduleName);
 
   // in builds we want to embed the canonical name for the handlebars runtime
   if (System.getCanonicalName) {
@@ -15,9 +15,9 @@ export function translate(load) {
   if (load.metadata.format === 'esm') {
     output = `import {Handlebars} from '${handlebarsRuntimePath}'; \n export default Handlebars.template(${precompiled});`;
   } else if (load.metadata.format === 'amd') {
-    output = `define(['${handlebarsRuntimePath}'], function(Handlebars) { return Handlebars.template(${precompiled}); });`;
+    output = `define(['${handlebarsRuntimePath}'], function (Handlebars) { return Handlebars.template(${precompiled}); });`;
   } else {
-    output = `var Handlebars=require('${handlebarsRuntimePath}'); \n module.exports = Handlebars.template(${precompiled});`;
+    output = `var Handlebars = require('${handlebarsRuntimePath}'); \n module.exports = Handlebars.template(${precompiled});`;
   }
   load.source = output;
   return output;


### PR DESCRIPTION
so basically the plugin works if you're using it on your own repo. however, if one of your dependencies depends on plugin-hbs, while your repo will work in the browser, it will not bundle. this PR fixes that issue.

also some minor code format changes
