### PR TITLE
Imports Handlebars as a non-named module

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -13,7 +13,7 @@ export function translate(load) {
 
   let output;
   if (load.metadata.format === 'esm') {
-    output = `import {Handlebars} from '${handlebarsRuntimePath}'; \n export default Handlebars.template(${precompiled});`;
+    output = `import Handlebars from '${handlebarsRuntimePath}'; \n export default Handlebars.template(${precompiled});`;
   } else if (load.metadata.format === 'amd') {
     output = `define(['${handlebarsRuntimePath}'], function (Handlebars) { return Handlebars.template(${precompiled}); });`;
   } else {


### PR DESCRIPTION
In PR #13 the meta `format` when set to `esm` would perform
```js
import {Handlebars} from 'handlebars/handlebars.runtime.js'; \n export default Handlebars.template(${precompiled});
```
But, since SystemJS [release v0.20.0](https://github.com/systemjs/systemjs/releases/tag/0.20.0), I quote:

> Breaking Changes:
>Removes the ability to use named imports from non-ES modules (eg import {readFile} from 'fs' should be import fs from 'fs'; fs.readFile).

So `import {Handlebars} ` now returns undefined. I guess nobody was using this meta, but anyway, with this PR I fixed that issue to import as the default export.

```js
import Handlebars from '${handlebarsRuntimePath}'; \n export default Handlebars.template(${precompiled});
```

Which returns the proper object.